### PR TITLE
Migrate ChartColorTemplates to enum with static vars

### DIFF
--- a/ChartsDemo-iOS/Swift/Demos/AnotherBarChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/AnotherBarChartViewController.swift
@@ -77,7 +77,7 @@ class AnotherBarChartViewController: DemoBaseViewController {
             chartView.notifyDataSetChanged()
         } else {
             set1 = BarChartDataSet(entries: yVals, label: "Data Set")
-            set1.colors = ChartColorTemplates.vordiplom()
+            set1.colors = ChartColorTemplates.vordiplom
             set1.drawValuesEnabled = false
             
             let data = BarChartData(dataSet: set1)

--- a/ChartsDemo-iOS/Swift/Demos/BarChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/BarChartViewController.swift
@@ -131,7 +131,7 @@ class BarChartViewController: DemoBaseViewController {
             chartView.notifyDataSetChanged()
         } else {
             set1 = BarChartDataSet(entries: yVals, label: "The year 2017")
-            set1.colors = ChartColorTemplates.material()
+            set1.colors = ChartColorTemplates.material
             set1.drawValuesEnabled = false
             
             let data = BarChartData(dataSet: set1)

--- a/ChartsDemo-iOS/Swift/Demos/BubbleChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/BubbleChartViewController.swift
@@ -93,17 +93,17 @@ class BubbleChartViewController: DemoBaseViewController {
         
         let set1 = BubbleChartDataSet(entries: yVals1, label: "DS 1")
         set1.drawIconsEnabled = false
-        set1.setColor(ChartColorTemplates.colorful()[0], alpha: 0.5)
+        set1.setColor(ChartColorTemplates.colorful[0], alpha: 0.5)
         set1.drawValuesEnabled = true
         
         let set2 = BubbleChartDataSet(entries: yVals2, label: "DS 2")
         set2.drawIconsEnabled = false
         set2.iconsOffset = CGPoint(x: 0, y: 15)
-        set2.setColor(ChartColorTemplates.colorful()[1], alpha: 0.5)
+        set2.setColor(ChartColorTemplates.colorful[1], alpha: 0.5)
         set2.drawValuesEnabled = true
         
         let set3 = BubbleChartDataSet(entries: yVals3, label: "DS 3")
-        set3.setColor(ChartColorTemplates.colorful()[2], alpha: 0.5)
+        set3.setColor(ChartColorTemplates.colorful[2], alpha: 0.5)
         set3.drawValuesEnabled = true
         
         let data = [set1, set2, set3] as BubbleChartData

--- a/ChartsDemo-iOS/Swift/Demos/CombinedChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/CombinedChartViewController.swift
@@ -191,7 +191,7 @@ class CombinedChartViewController: DemoBaseViewController {
         }
         
         let set = ScatterChartDataSet(entries: entries, label: "Scatter DataSet")
-        set.colors = ChartColorTemplates.material()
+        set.colors = ChartColorTemplates.material
         set.scatterShapeSize = 4.5
         set.drawValuesEnabled = false
         set.valueFont = .systemFont(ofSize: 10)
@@ -222,7 +222,7 @@ class CombinedChartViewController: DemoBaseViewController {
         }
         
         let set = BubbleChartDataSet(entries: entries, label: "Bubble DataSet")
-        set.setColors(ChartColorTemplates.vordiplom(), alpha: 1)
+        set.setColors(ChartColorTemplates.vordiplom, alpha: 1)
         set.valueTextColor = .white
         set.valueFont = .systemFont(ofSize: 10)
         set.drawValuesEnabled = true

--- a/ChartsDemo-iOS/Swift/Demos/HalfPieChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/HalfPieChartViewController.swift
@@ -85,7 +85,7 @@ class HalfPieChartViewController: DemoBaseViewController {
         let set = PieChartDataSet(entries: entries, label: "Election Results")
         set.sliceSpace = 3
         set.selectionShift = 5
-        set.colors = ChartColorTemplates.material()
+        set.colors = ChartColorTemplates.material
         
         let data = PieChartData(dataSet: set)
         

--- a/ChartsDemo-iOS/Swift/Demos/LineChart1ViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/LineChart1ViewController.swift
@@ -120,8 +120,10 @@ class LineChart1ViewController: DemoBaseViewController {
 
         let value = ChartDataEntry(x: Double(3), y: 3)
         set1.addEntryOrdered(value)
-        let gradientColors = [ChartColorTemplates.colorFromString("#00ff0000").cgColor,
-                              ChartColorTemplates.colorFromString("#ffff0000").cgColor]
+        let gradientColors = [
+             UIColor(red: 1, green: 0, blue: 0, alpha: 0),
+             UIColor(red: 1, green: 0, blue: 0, alpha: 1)
+         ]
         let gradient = CGGradient(colorsSpace: nil, colors: gradientColors as CFArray, locations: nil)!
 
         set1.fillAlpha = 1

--- a/ChartsDemo-iOS/Swift/Demos/MultipleLinesChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/MultipleLinesChartViewController.swift
@@ -72,7 +72,7 @@ class MultipleLinesChartViewController: DemoBaseViewController {
     
     // TODO: Refine data creation
     func setDataCount(_ count: Int, range: UInt32) {
-        let colors = ChartColorTemplates.vordiplom()[0...2]
+        let colors = ChartColorTemplates.vordiplom[0...2]
         
         let block: (Int) -> ChartDataEntry = { (i) -> ChartDataEntry in
             let val = Double(arc4random_uniform(range) + 3)
@@ -92,8 +92,8 @@ class MultipleLinesChartViewController: DemoBaseViewController {
         }
         
         dataSets[0].lineDashLengths = [5, 5]
-        dataSets[0].colors = ChartColorTemplates.vordiplom()
-        dataSets[0].circleColors = ChartColorTemplates.vordiplom()
+        dataSets[0].colors = ChartColorTemplates.vordiplom
+        dataSets[0].circleColors = ChartColorTemplates.vordiplom
         
         let data = LineChartData(dataSets: dataSets)
         data.setValueFont(.systemFont(ofSize: 7, weight: .light))

--- a/ChartsDemo-iOS/Swift/Demos/PieChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/PieChartViewController.swift
@@ -85,13 +85,14 @@ class PieChartViewController: DemoBaseViewController {
         set.sliceSpace = 2
         
         
-        set.colors = ChartColorTemplates.vordiplom()
-            + ChartColorTemplates.joyful()
-            + ChartColorTemplates.colorful()
-            + ChartColorTemplates.liberty()
-            + ChartColorTemplates.pastel()
+        let colors = ChartColorTemplates.vordiplom
+            + ChartColorTemplates.joyful
+            + ChartColorTemplates.colorful
+            + ChartColorTemplates.liberty
+            + ChartColorTemplates.pastel
             + [UIColor(red: 51/255, green: 181/255, blue: 229/255, alpha: 1)]
-        
+        set.colors = colors
+
         let data = PieChartData(dataSet: set)
         
         let pFormatter = NumberFormatter()

--- a/ChartsDemo-iOS/Swift/Demos/PiePolylineChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/PiePolylineChartViewController.swift
@@ -69,13 +69,14 @@ class PiePolylineChartViewController: DemoBaseViewController {
         let set = PieChartDataSet(entries: entries, label: "Election Results")
         set.sliceSpace = 2
         
-        
-        set.colors = ChartColorTemplates.vordiplom()
-            + ChartColorTemplates.joyful()
-            + ChartColorTemplates.colorful()
-            + ChartColorTemplates.liberty()
-            + ChartColorTemplates.pastel()
+
+        let colors = ChartColorTemplates.vordiplom
+            + ChartColorTemplates.joyful
+            + ChartColorTemplates.colorful
+            + ChartColorTemplates.liberty
+            + ChartColorTemplates.pastel
             + [UIColor(red: 51/255, green: 181/255, blue: 229/255, alpha: 1)]
+        set.colors = colors
         
         set.valueLinePart1OffsetPercentage = 0.8
         set.valueLinePart1Length = 0.2

--- a/ChartsDemo-iOS/Swift/Demos/ScatterChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/ScatterChartViewController.swift
@@ -92,19 +92,19 @@ class ScatterChartViewController: DemoBaseViewController {
         
         let set1 = ScatterChartDataSet(entries: values1, label: "DS 1")
         set1.setScatterShape(.square)
-        set1.setColor(ChartColorTemplates.colorful()[0])
+        set1.setColor(ChartColorTemplates.colorful[0])
         set1.scatterShapeSize = 8
         
         let set2 = ScatterChartDataSet(entries: values2, label: "DS 2")
         set2.setScatterShape(.circle)
-        set2.scatterShapeHoleColor = ChartColorTemplates.colorful()[3]
+        set2.scatterShapeHoleColor = ChartColorTemplates.colorful[3]
         set2.scatterShapeHoleRadius = 3.5
-        set2.setColor(ChartColorTemplates.colorful()[1])
+        set2.setColor(ChartColorTemplates.colorful[1])
         set2.scatterShapeSize = 8
         
         let set3 = ScatterChartDataSet(entries: values3, label: "DS 3")
         set3.setScatterShape(.cross)
-        set3.setColor(ChartColorTemplates.colorful()[2])
+        set3.setColor(ChartColorTemplates.colorful[2])
         set3.scatterShapeSize = 8
         
         let data: ScatterChartData = [set1, set2, set3]

--- a/ChartsDemo-iOS/Swift/Demos/StackedBarChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/StackedBarChartViewController.swift
@@ -102,7 +102,8 @@ class StackedBarChartViewController: DemoBaseViewController {
         
         let set = BarChartDataSet(entries: yVals, label: "Statistics Vienna 2014")
         set.drawIconsEnabled = false
-        set.colors = [ChartColorTemplates.material()[0], ChartColorTemplates.material()[1], ChartColorTemplates.material()[2]]
+
+        set.colors = Array(ChartColorTemplates.material[0..<3])
         set.stackLabels = ["Births", "Divorces", "Marriages"]
         
         let data = BarChartData(dataSet: set)

--- a/ChartsDemo-macOS/ChartsDemo-macOS/Demos/PieDemoViewController.swift
+++ b/ChartsDemo-macOS/ChartsDemo-macOS/Demos/PieDemoViewController.swift
@@ -28,7 +28,7 @@ open class PieDemoViewController: NSViewController
         let data = PieChartData()
         let ds1 = PieChartDataSet(entries: yse1, label: "Hello")
         
-        ds1.colors = ChartColorTemplates.vordiplom()
+        ds1.colors = ChartColorTemplates.vordiplom
         
         data.append(ds1)
         

--- a/Source/Charts/Utils/ChartColorTemplates.swift
+++ b/Source/Charts/Utils/ChartColorTemplates.swift
@@ -14,9 +14,9 @@ import CoreGraphics
 
 public enum ChartColorTemplates
 {
-    public static func liberty () -> [NSUIColor]
+    public static var liberty: [NSUIColor]
     {
-        return [
+        [
             NSUIColor(red: 207/255.0, green: 248/255.0, blue: 246/255.0, alpha: 1.0),
             NSUIColor(red: 148/255.0, green: 212/255.0, blue: 212/255.0, alpha: 1.0),
             NSUIColor(red: 136/255.0, green: 180/255.0, blue: 187/255.0, alpha: 1.0),
@@ -25,9 +25,9 @@ public enum ChartColorTemplates
         ]
     }
     
-    public static func joyful () -> [NSUIColor]
+    public static var joyful: [NSUIColor]
     {
-        return [
+        [
             NSUIColor(red: 217/255.0, green: 80/255.0, blue: 138/255.0, alpha: 1.0),
             NSUIColor(red: 254/255.0, green: 149/255.0, blue: 7/255.0, alpha: 1.0),
             NSUIColor(red: 254/255.0, green: 247/255.0, blue: 120/255.0, alpha: 1.0),
@@ -36,9 +36,9 @@ public enum ChartColorTemplates
         ]
     }
     
-    public static func pastel () -> [NSUIColor]
+    public static var pastel: [NSUIColor]
     {
-        return [
+        [
             NSUIColor(red: 64/255.0, green: 89/255.0, blue: 128/255.0, alpha: 1.0),
             NSUIColor(red: 149/255.0, green: 165/255.0, blue: 124/255.0, alpha: 1.0),
             NSUIColor(red: 217/255.0, green: 184/255.0, blue: 162/255.0, alpha: 1.0),
@@ -47,9 +47,9 @@ public enum ChartColorTemplates
         ]
     }
     
-    public static func colorful () -> [NSUIColor]
+    public static var colorful: [NSUIColor]
     {
-        return [
+        [
             NSUIColor(red: 193/255.0, green: 37/255.0, blue: 82/255.0, alpha: 1.0),
             NSUIColor(red: 255/255.0, green: 102/255.0, blue: 0/255.0, alpha: 1.0),
             NSUIColor(red: 245/255.0, green: 199/255.0, blue: 0/255.0, alpha: 1.0),
@@ -58,9 +58,9 @@ public enum ChartColorTemplates
         ]
     }
     
-    public static func vordiplom () -> [NSUIColor]
+    public static var vordiplom: [NSUIColor]
     {
-        return [
+        [
             NSUIColor(red: 192/255.0, green: 255/255.0, blue: 140/255.0, alpha: 1.0),
             NSUIColor(red: 255/255.0, green: 247/255.0, blue: 140/255.0, alpha: 1.0),
             NSUIColor(red: 255/255.0, green: 208/255.0, blue: 140/255.0, alpha: 1.0),
@@ -69,126 +69,13 @@ public enum ChartColorTemplates
         ]
     }
     
-    public static func material () -> [NSUIColor]
+    public static var material: [NSUIColor]
     {
-        return [
+        [
             NSUIColor(red: 46/255.0, green: 204/255.0, blue: 113/255.0, alpha: 1.0),
             NSUIColor(red: 241/255.0, green: 196/255.0, blue: 15/255.0, alpha: 1.0),
             NSUIColor(red: 231/255.0, green: 76/255.0, blue: 60/255.0, alpha: 1.0),
             NSUIColor(red: 52/255.0, green: 152/255.0, blue: 219/255.0, alpha: 1.0)
         ]
-    }
-    
-    public static func colorFromString(_ colorString: String) -> NSUIColor
-    {
-        let leftParenCharset: CharacterSet = CharacterSet(charactersIn: "( ")
-        let commaCharset: CharacterSet = CharacterSet(charactersIn: ", ")
-
-        let colorString = colorString.lowercased()
-        
-        if colorString.hasPrefix("#")
-        {
-            var argb: [UInt] = [255, 0, 0, 0]
-            let colorString = colorString.unicodeScalars.dropFirst()
-            let length = colorString.count
-            var index = colorString.startIndex
-            let endIndex = colorString.endIndex
-
-            guard [3, 6, 8].contains(length) else { return .black }
-
-            var i = length == 8 ? 0 : 1
-            while index < endIndex
-            {
-                var c = colorString[index]
-                index = colorString.index(after: index)
-
-                var val = (c.value >= 0x61 && c.value <= 0x66) ? (c.value - 0x61 + 10) : c.value - 0x30
-                argb[i] = UInt(val) * 16
-                if length == 3
-                {
-                    argb[i] = argb[i] + UInt(val)
-                }
-                else
-                {
-                    c = colorString[index]
-                    index = colorString.index(after: index)
-
-                    val = (c.value >= 0x61 && c.value <= 0x66) ? (c.value - 0x61 + 10) : c.value - 0x30
-                    argb[i] = argb[i] + UInt(val)
-                }
-
-                i += 1
-            }
-
-            return NSUIColor(red: CGFloat(argb[1]) / 255.0, green: CGFloat(argb[2]) / 255.0, blue: CGFloat(argb[3]) / 255.0, alpha: CGFloat(argb[0]) / 255.0)
-        }
-        else if colorString.hasPrefix("rgba")
-        {
-            var a: Float = 1.0
-            var r: Int32 = 0
-            var g: Int32 = 0
-            var b: Int32 = 0
-            let scanner: Scanner = Scanner(string: colorString)
-            scanner.scanString("rgba", into: nil)
-            scanner.scanCharacters(from: leftParenCharset, into: nil)
-            scanner.scanInt32(&r)
-            scanner.scanCharacters(from: commaCharset, into: nil)
-            scanner.scanInt32(&g)
-            scanner.scanCharacters(from: commaCharset, into: nil)
-            scanner.scanInt32(&b)
-            scanner.scanCharacters(from: commaCharset, into: nil)
-            scanner.scanFloat(&a)
-            return NSUIColor(
-                red: CGFloat(r) / 255.0,
-                green: CGFloat(g) / 255.0,
-                blue: CGFloat(b) / 255.0,
-                alpha: CGFloat(a)
-            )
-        }
-        else if colorString.hasPrefix("argb")
-        {
-            var a: Float = 1.0
-            var r: Int32 = 0
-            var g: Int32 = 0
-            var b: Int32 = 0
-            let scanner: Scanner = Scanner(string: colorString)
-            scanner.scanString("argb", into: nil)
-            scanner.scanCharacters(from: leftParenCharset, into: nil)
-            scanner.scanFloat(&a)
-            scanner.scanCharacters(from: commaCharset, into: nil)
-            scanner.scanInt32(&r)
-            scanner.scanCharacters(from: commaCharset, into: nil)
-            scanner.scanInt32(&g)
-            scanner.scanCharacters(from: commaCharset, into: nil)
-            scanner.scanInt32(&b)
-            return NSUIColor(
-                red: CGFloat(r) / 255.0,
-                green: CGFloat(g) / 255.0,
-                blue: CGFloat(b) / 255.0,
-                alpha: CGFloat(a)
-            )
-        }
-        else if colorString.hasPrefix("rgb")
-        {
-            var r: Int32 = 0
-            var g: Int32 = 0
-            var b: Int32 = 0
-            let scanner: Scanner = Scanner(string: colorString)
-            scanner.scanString("rgb", into: nil)
-            scanner.scanCharacters(from: leftParenCharset, into: nil)
-            scanner.scanInt32(&r)
-            scanner.scanCharacters(from: commaCharset, into: nil)
-            scanner.scanInt32(&g)
-            scanner.scanCharacters(from: commaCharset, into: nil)
-            scanner.scanInt32(&b)
-            return NSUIColor(
-                red: CGFloat(r) / 255.0,
-                green: CGFloat(g) / 255.0,
-                blue: CGFloat(b) / 255.0,
-                alpha: 1.0
-            )
-        }
-        
-        return NSUIColor.clear
     }
 }


### PR DESCRIPTION
### Issue Link :link:
Custom creation of `UIColor` is outside the problem domain of creating charts. There are many publicly available implementations of this and methods like the method removed. It is only a maintenance burden as surfaced by #4452. 

Additionally, the built-in color templates should not be overridden, so they are now public instead of open. They are also computed properties instead of functions to follow Swift API standards.

### Goals :soccer:
Remove unnecessary maintenance burden. Improve API.