### PR TITLE
Remove unnecessary enum backing value

### DIFF
--- a/Source/Charts/Animation/ChartAnimationEasing.swift
+++ b/Source/Charts/Animation/ChartAnimationEasing.swift
@@ -12,7 +12,7 @@
 import CoreGraphics
 import Foundation
 
-public enum ChartEasingOption: Int {
+public enum ChartEasingOption {
     case linear
     case easeInQuad
     case easeOutQuad

--- a/Source/Charts/Charts/CombinedChartView.swift
+++ b/Source/Charts/Charts/CombinedChartView.swift
@@ -18,7 +18,7 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider {
     internal var _fillFormatter: FillFormatter!
 
     /// enum that allows to specify the order in which the different data objects for the combined-chart are drawn
-    public enum DrawOrder: Int {
+    public enum DrawOrder {
         case bar
         case bubble
         case line
@@ -147,13 +147,9 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider {
     /// the order in which the provided data objects should be drawn.
     /// The earlier you place them in the provided array, the further they will be in the background.
     /// e.g. if you provide [DrawOrder.Bar, DrawOrder.Line], the bars will be drawn behind the lines.
-    open var drawOrder: [Int] {
-        get {
-            return (renderer as! CombinedChartRenderer).drawOrder.map { $0.rawValue }
-        }
-        set {
-            (renderer as! CombinedChartRenderer).drawOrder = newValue.map { DrawOrder(rawValue: $0)! }
-        }
+    open var drawOrder: [DrawOrder] {
+        get { (renderer as! CombinedChartRenderer).drawOrder }
+        set { (renderer as! CombinedChartRenderer).drawOrder = newValue }
     }
 
     /// Set this to `true` to make the highlight operation full-bar oriented, `false` to make it highlight single values

--- a/Source/Charts/Components/ChartLimitLine.swift
+++ b/Source/Charts/Components/ChartLimitLine.swift
@@ -15,7 +15,7 @@ import Foundation
 /// The limit line is an additional feature for all Line, Bar and ScatterCharts.
 /// It allows the displaying of an additional line in the chart that marks a certain maximum / limit on the specified axis (x- or y-axis).
 open class ChartLimitLine: ComponentBase {
-    public enum LabelPosition: Int {
+    public enum LabelPosition {
         case leftTop
         case leftBottom
         case rightTop

--- a/Source/Charts/Components/Legend.swift
+++ b/Source/Charts/Components/Legend.swift
@@ -13,7 +13,7 @@ import CoreGraphics
 import Foundation
 
 open class Legend: ComponentBase {
-    public enum Form: Int {
+    public enum Form {
         /// Avoid drawing a form
         case none
 
@@ -33,24 +33,24 @@ open class Legend: ComponentBase {
         case line
     }
 
-    public enum HorizontalAlignment: Int {
+    public enum HorizontalAlignment {
         case left
         case center
         case right
     }
 
-    public enum VerticalAlignment: Int {
+    public enum VerticalAlignment {
         case top
         case center
         case bottom
     }
 
-    public enum Orientation: Int {
+    public enum Orientation {
         case horizontal
         case vertical
     }
 
-    public enum Direction: Int {
+    public enum Direction {
         case leftToRight
         case rightToLeft
     }

--- a/Source/Charts/Components/XAxis.swift
+++ b/Source/Charts/Components/XAxis.swift
@@ -13,7 +13,7 @@ import CoreGraphics
 import Foundation
 
 open class XAxis: AxisBase {
-    public enum LabelPosition: Int {
+    public enum LabelPosition {
         case top
         case bottom
         case bothSided

--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -24,13 +24,13 @@ import Foundation
 /// Be aware that not all features the YLabels class provides are suitable for the RadarChart.
 /// Customizations that affect the value range of the axis need to be applied before setting data for the chart.
 open class YAxis: AxisBase {
-    public enum LabelPosition: Int {
+    public enum LabelPosition {
         case outsideChart
         case insideChart
     }
 
     ///  Enum that specifies the axis a DataSet should be plotted against, either Left or Right.
-    public enum AxisDependency: Int {
+    public enum AxisDependency {
         case left
         case right
     }

--- a/Source/Charts/Data/ChartDataSet/ChartDataSet.swift
+++ b/Source/Charts/Data/ChartDataSet/ChartDataSet.swift
@@ -14,10 +14,10 @@ import Foundation
 import CoreGraphics
 
 /// Determines how to round DataSet index values for `ChartDataSet.entryIndex(x, rounding)` when an exact x-value is not found.
-public enum ChartDataSetRounding: Int {
-    case up = 0
-    case down = 1
-    case closest = 2
+public enum ChartDataSetRounding {
+    case up
+    case down
+    case closest
 }
 
 /// The DataSet class represents one group or type of entries (Entry) in the Chart that belong together.

--- a/Source/Charts/Data/ChartDataSet/LineChartDataSet.swift
+++ b/Source/Charts/Data/ChartDataSet/LineChartDataSet.swift
@@ -13,7 +13,7 @@ import CoreGraphics
 import Foundation
 
 open class LineChartDataSet: LineRadarChartDataSet, LineChartDataSetProtocol {
-    public enum Mode: Int {
+    public enum Mode {
         case linear
         case stepped
         case cubicBezier

--- a/Source/Charts/Data/ChartDataSet/PieChartDataSet.swift
+++ b/Source/Charts/Data/ChartDataSet/PieChartDataSet.swift
@@ -13,7 +13,7 @@ import CoreGraphics
 import Foundation
 
 open class PieChartDataSet: ChartDataSet, PieChartDataSetProtocol {
-    public enum ValuePosition: Int {
+    public enum ValuePosition {
         case insideSlice
         case outsideSlice
     }

--- a/Source/Charts/Data/ChartDataSet/ScatterChartDataSet.swift
+++ b/Source/Charts/Data/ChartDataSet/ScatterChartDataSet.swift
@@ -13,7 +13,7 @@ import CoreGraphics
 import Foundation
 
 open class ScatterChartDataSet: LineScatterCandleRadarChartDataSet, ScatterChartDataSetProtocol {
-    public enum Shape: Int {
+    public enum Shape {
         case square
         case circle
         case triangle


### PR DESCRIPTION
The backing values are unnecessary for enums now that objc is not supported in the main codebase.